### PR TITLE
Replace smartmatch with any/none from List::MoreUtils

### DIFF
--- a/lib/DBIx/Class/Result/Validation.pm
+++ b/lib/DBIx/Class/Result/Validation.pm
@@ -9,6 +9,7 @@ use Scalar::Util 'blessed';
 use DBIx::Class::Result::Validation::VException;
 use DateTime;
 use DateTime::Set;
+use List::MoreUtils qw(any none);
 
 =head1 NAME
 
@@ -306,7 +307,7 @@ sub validate_enum {
     if( 
             (!defined ($self->$field) && !defined($self->result_source->columns_info->{$field}->{default_value})
             or  
-            (defined ($self->$field) && !($self->$field ~~ @{ $self->result_source->columns_info->{$field}->{extra}->{list} }))
+            (defined ($self->$field) && none { $_ eq $self->$field } @{ $self->result_source->columns_info->{$field}->{extra}->{list} })
       )
     );
 }
@@ -379,7 +380,7 @@ sub validate_prohibit_field_update {
     if (defined $self->$field && defined $self->id){
         my $previous_field_value = $self->get_from_storage->$field;
         $self->add_result_error( $field, "$field has no data_type defined, it must be defined when prohibit_field_update is used") if (!defined $self->result_source->columns_info->{$field}->{data_type});
-        if ( $self->result_source->columns_info->{$field}->{data_type} ~~ @NUMERICAL_DATA_TYPE){
+        if ( any { $_ eq $self->result_source->columns_info->{$field}->{data_type} } @NUMERICAL_DATA_TYPE){
             $self->add_result_error( $field, "$field can not be updated to ".$self->$field ." : Not authorized") if (!defined $previous_field_value || $previous_field_value != $self->$field);
         }
         else{


### PR DESCRIPTION
The intent is to eliminate "Smartmatch is experimental" warnings...

This seems like a reasonable use of Smartmatch, but the community seems to recommend against using Smartmatch, so I opted for List::MoreUtils...